### PR TITLE
Deploy VictoriaMetrics Alert (vmalert)

### DIFF
--- a/modules/prometheus/locals.tf
+++ b/modules/prometheus/locals.tf
@@ -1,9 +1,11 @@
 locals {
   prometheus_remote_write_api_url = var.vm_enabled && var.vm_insert_enabled ? "http://${helm_release.vm[0].metadata[0].name}-vminsert.${helm_release.vm[0].metadata[0].namespace}.svc.cluster.local:${var.vm_insert_service_port}/insert/0/prometheus" : ""
 
-  prometheus_query_api_url = var.vm_enabled && var.vm_select_enabled ?
+  prometheus_query_api_url = (
+    var.vm_enabled && var.vm_select_enabled ?
     "http://${helm_release.vm[0].metadata[0].name}-vmselect.${helm_release.vm[0].metadata[0].namespace}.svc.cluster.local:${var.vm_select_service_port}/select/0/prometheus" :
     "http://${helm_release.prometheus[0].metadata[0].name}-server.${helm_release.prometheus[0].metadata[0].namespace}.svc.cluster.local:${var.server_service_port}"
+  )
 
   prometheus_alertmanager_url = "http://${helm_release.prometheus[0].metadata[0].name}-alertmanager.${helm_release.prometheus[0].metadata[0].namespace}.svc.cluster.local:${var.alertmanager_service_port}"
 }

--- a/modules/prometheus/locals.tf
+++ b/modules/prometheus/locals.tf
@@ -4,8 +4,8 @@ locals {
 
   prometheus_query_api_url = coalesce(
     local.prometheus_remote_read_api_url,
-    "http://${helm_release.prometheus[0].metadata[0].name}-server.${helm_release.prometheus[0].metadata[0].namespace}.svc.cluster.local:${var.server_service_port}"
+    "http://${helm_release.prometheus.metadata[0].name}-server.${helm_release.prometheus.metadata[0].namespace}.svc.cluster.local:${var.server_service_port}"
   )
 
-  prometheus_alertmanager_url = "http://${helm_release.prometheus[0].metadata[0].name}-alertmanager.${helm_release.prometheus[0].metadata[0].namespace}.svc.cluster.local:${var.alertmanager_service_port}"
+  prometheus_alertmanager_url = "http://${helm_release.prometheus.metadata[0].name}-alertmanager.${helm_release.prometheus.metadata[0].namespace}.svc.cluster.local:${var.alertmanager_service_port}"
 }

--- a/modules/prometheus/locals.tf
+++ b/modules/prometheus/locals.tf
@@ -1,9 +1,9 @@
 locals {
   prometheus_remote_write_api_url = var.vm_enabled && var.vm_insert_enabled ? "http://${helm_release.vm[0].metadata[0].name}-vminsert.${helm_release.vm[0].metadata[0].namespace}.svc.cluster.local:${var.vm_insert_service_port}/insert/0/prometheus" : ""
+  prometheus_remote_read_api_url  = var.vm_enabled && var.vm_select_enabled ? "http://${helm_release.vm[0].metadata[0].name}-vmselect.${helm_release.vm[0].metadata[0].namespace}.svc.cluster.local:${var.vm_select_service_port}/select/0/prometheus" : ""
 
-  prometheus_query_api_url = (
-    var.vm_enabled && var.vm_select_enabled ?
-    "http://${helm_release.vm[0].metadata[0].name}-vmselect.${helm_release.vm[0].metadata[0].namespace}.svc.cluster.local:${var.vm_select_service_port}/select/0/prometheus" :
+  prometheus_query_api_url = coalesce(
+    local.prometheus_remote_read_api_url,
     "http://${helm_release.prometheus[0].metadata[0].name}-server.${helm_release.prometheus[0].metadata[0].namespace}.svc.cluster.local:${var.server_service_port}"
   )
 

--- a/modules/prometheus/locals.tf
+++ b/modules/prometheus/locals.tf
@@ -1,11 +1,14 @@
 locals {
+  prometheus_server_url       = "http://${helm_release.prometheus.metadata[0].name}-server.${helm_release.prometheus.metadata[0].namespace}.svc.cluster.local:${var.server_service_port}"
+  prometheus_alertmanager_url = "http://${helm_release.prometheus.metadata[0].name}-alertmanager.${helm_release.prometheus.metadata[0].namespace}.svc.cluster.local:${var.alertmanager_service_port}"
+
   prometheus_remote_write_api_url = var.vm_enabled && var.vm_insert_enabled ? "http://${helm_release.vm[0].metadata[0].name}-vminsert.${helm_release.vm[0].metadata[0].namespace}.svc.cluster.local:${var.vm_insert_service_port}/insert/0/prometheus" : ""
   prometheus_remote_read_api_url  = var.vm_enabled && var.vm_select_enabled ? "http://${helm_release.vm[0].metadata[0].name}-vmselect.${helm_release.vm[0].metadata[0].namespace}.svc.cluster.local:${var.vm_select_service_port}/select/0/prometheus" : ""
 
-  prometheus_query_api_url = coalesce(
-    local.prometheus_remote_read_api_url,
-    "http://${helm_release.prometheus.metadata[0].name}-server.${helm_release.prometheus.metadata[0].namespace}.svc.cluster.local:${var.server_service_port}"
+  prometheus_query_api_url = coalesce(local.prometheus_remote_read_api_url, local.prometheus_server_url)
+  prometheus_alerts_api_url = (
+    var.vm_enabled && var.vm_alert_enabled ?
+    "http://${helm_release.vm_alert[0].metadata[0].name}-server.${helm_release.vm_alert[0].metadata[0].namespace}.svc.cluster.local:${var.vm_alert_service_port}" :
+    local.prometheus_server_url
   )
-
-  prometheus_alertmanager_url = "http://${helm_release.prometheus.metadata[0].name}-alertmanager.${helm_release.prometheus.metadata[0].namespace}.svc.cluster.local:${var.alertmanager_service_port}"
 }

--- a/modules/prometheus/locals.tf
+++ b/modules/prometheus/locals.tf
@@ -1,0 +1,9 @@
+locals {
+  prometheus_remote_write_api_url = var.vm_enabled && var.vm_insert_enabled ? "http://${helm_release.vm[0].metadata[0].name}-vminsert.${helm_release.vm[0].metadata[0].namespace}.svc.cluster.local:${var.vm_insert_service_port}/insert/0/prometheus" : ""
+
+  prometheus_query_api_url = var.vm_enabled && var.vm_select_enabled ?
+    "http://${helm_release.vm[0].metadata[0].name}-vmselect.${helm_release.vm[0].metadata[0].namespace}.svc.cluster.local:${var.vm_select_service_port}/select/0/prometheus" :
+    "http://${helm_release.prometheus[0].metadata[0].name}-server.${helm_release.prometheus[0].metadata[0].namespace}.svc.cluster.local:${var.server_service_port}"
+
+  prometheus_alertmanager_url = "http://${helm_release.prometheus[0].metadata[0].name}-alertmanager.${helm_release.prometheus[0].metadata[0].namespace}.svc.cluster.local:${var.alertmanager_service_port}"
+}

--- a/modules/prometheus/main.tf
+++ b/modules/prometheus/main.tf
@@ -282,8 +282,8 @@ locals {
     retention           = jsonencode(var.server_data_retention)
     additional_global   = var.server_additional_global
 
-    alerts        = indent(2, var.server_alerts)
-    rules         = indent(2, var.server_rules)
+    alerts        = var.vm_alert_enabled ? "" : indent(2, var.server_alerts)
+    rules         = var.vm_alert_enabled ? "" : indent(2, var.server_rules)
     server_config = indent(2, data.template_file.server_config.rendered)
 
     pod_security_policy_annotations = jsonencode(var.server_pod_security_policy_annotations)

--- a/modules/prometheus/main.tf
+++ b/modules/prometheus/main.tf
@@ -313,7 +313,7 @@ data "template_file" "server_config" {
     remote_read_configs = var.vm_enabled && var.vm_select_enabled ? indent(2, yamlencode({
       remote_read = [
         {
-          url = local.prometheus_query_api_url
+          url = local.prometheus_remote_read_api_url
         }
       ]
     })) : ""

--- a/modules/prometheus/main.tf
+++ b/modules/prometheus/main.tf
@@ -282,8 +282,8 @@ locals {
     retention           = jsonencode(var.server_data_retention)
     additional_global   = var.server_additional_global
 
-    alerts        = var.vm_alert_enabled ? "" : indent(2, var.server_alerts)
-    rules         = var.vm_alert_enabled ? "" : indent(2, var.server_rules)
+    alerts        = var.vm_alert_enabled ? "[]" : indent(6, var.server_alerts)
+    rules         = var.vm_alert_enabled ? "[]" : indent(6, var.server_rules)
     server_config = indent(2, data.template_file.server_config.rendered)
 
     pod_security_policy_annotations = jsonencode(var.server_pod_security_policy_annotations)

--- a/modules/prometheus/outputs.tf
+++ b/modules/prometheus/outputs.tf
@@ -12,3 +12,8 @@ output "prometheus_query_api_url" {
   description = "Prometheus query API URL: https://prometheus.io/docs/prometheus/latest/querying/api/#expression-queries"
   value       = local.prometheus_query_api_url
 }
+
+output "prometheus_alerts_api_url" {
+  description = "Prometheus query API URL: https://prometheus.io/docs/prometheus/latest/querying/api/#expression-queries"
+  value       = local.prometheus_alerts_api_url
+}

--- a/modules/prometheus/outputs.tf
+++ b/modules/prometheus/outputs.tf
@@ -3,6 +3,11 @@ output "prometheus_remote_write_api_url" {
   value       = local.prometheus_remote_write_api_url
 }
 
+output "prometheus_remote_read_api_url" {
+  description = "Prometheus Remote Read API URL: https://prometheus.io/docs/prometheus/latest/storage/#remote-storage-integrations"
+  value       = local.prometheus_remote_read_api_url
+}
+
 output "prometheus_query_api_url" {
   description = "Prometheus query API URL: https://prometheus.io/docs/prometheus/latest/querying/api/#expression-queries"
   value       = local.prometheus_query_api_url

--- a/modules/prometheus/templates/server.yaml
+++ b/modules/prometheus/templates/server.yaml
@@ -296,6 +296,10 @@ server:
   livenessProbeTimeout: ${liveness_probe_timeout}
 
 serverFiles:
-  ${alerts}
-  ${rules}
+  alerts:
+    groups:
+      ${alerts}
+  rules:
+    groups:
+      ${rules}
   ${server_config}

--- a/modules/prometheus/templates/victoriametrics-alert.yaml
+++ b/modules/prometheus/templates/victoriametrics-alert.yaml
@@ -56,3 +56,4 @@ server:
   configMap: ""
   config:
     ${alerts}
+    ${rules}

--- a/modules/prometheus/templates/victoriametrics-alert.yaml
+++ b/modules/prometheus/templates/victoriametrics-alert.yaml
@@ -56,5 +56,6 @@ server:
   configMap: ""
   config:
     alerts:
-      ${alerts}
-      ${rules}
+      groups:
+        ${alerts}
+        ${rules}

--- a/modules/prometheus/templates/victoriametrics-alert.yaml
+++ b/modules/prometheus/templates/victoriametrics-alert.yaml
@@ -1,0 +1,58 @@
+serviceAccount:
+  create: true
+
+alertmanager:
+  enabled: false
+
+server:
+  name: server
+  enabled: ${enabled}
+  image:
+    repository: ${image_repository}
+    tag: ${image_tag}
+    pullPolicy: IfNotPresent
+  replicaCount: ${replica_count}
+  # vmalert reads metrics from source, next section represents its configuration.
+  # It can be any service which supports MetricsQL or PromQL.
+  datasource:
+    url: ${datasource_url}
+
+  remote:
+    write:
+      url: ${remote_write_url}
+    read:
+      url: ${remote_read_url}
+
+  notifier:
+    alertmanager:
+      url: ${alertmanager_url}
+
+  extraArgs: ${extra_args}
+
+  service:
+    annotations: ${service_annotations}
+    labels: ${service_labels}
+    servicePort: ${service_port}
+    type: ${service_type}
+
+  ingress:
+    enabled: false
+
+  podSecurityContext: ${security_context}
+
+  resources: ${resources}
+
+  podAnnotations: ${pod_annotations}
+
+  nodeSelector: ${node_selector}
+
+  tolerations: ${tolerations}
+
+  affinity: ${affinity}
+
+  # vmalert alert rules configuration configuration:
+  # use existing configmap if specified
+  # otherwise .config values will be used
+  configMap: ""
+  config:
+    ${alerts}

--- a/modules/prometheus/templates/victoriametrics-alert.yaml
+++ b/modules/prometheus/templates/victoriametrics-alert.yaml
@@ -55,5 +55,6 @@ server:
   # otherwise .config values will be used
   configMap: ""
   config:
-    ${alerts}
-    ${rules}
+    alerts:
+      ${alerts}
+      ${rules}

--- a/modules/prometheus/variables.tf
+++ b/modules/prometheus/variables.tf
@@ -1376,7 +1376,7 @@ variable "vm_chart_repository_url" {
 
 variable "vm_chart_version" {
   description = "Chart version for VictoriaMetrics"
-  default     = "0.4.4"
+  default     = "0.5.15"
 }
 
 variable "vm_namespace" {
@@ -1409,7 +1409,7 @@ variable "vm_select_image_repository" {
 
 variable "vm_select_image_tag" {
   description = "Image tag for VictoriaMetrics Select server"
-  default     = "v1.37.0-cluster"
+  default     = "v1.37.4-cluster"
 }
 
 variable "vm_select_priority_class_name" {
@@ -1515,7 +1515,7 @@ variable "vm_insert_image_repository" {
 
 variable "vm_insert_image_tag" {
   description = "Image tag for VictoriaMetrics Insert server"
-  default     = "v1.37.0-cluster"
+  default     = "v1.37.4-cluster"
 }
 
 variable "vm_insert_priority_class_name" {
@@ -1598,7 +1598,7 @@ variable "vm_storage_image_repository" {
 
 variable "vm_storage_image_tag" {
   description = "Image tag for VictoriaMetrics Storage server"
-  default     = "v1.37.0-cluster"
+  default     = "v1.37.4-cluster"
 }
 
 variable "vm_storage_priority_class_name" {

--- a/modules/prometheus/variables.tf
+++ b/modules/prometheus/variables.tf
@@ -1306,11 +1306,9 @@ variable "server_liveness_probe_timeout" {
 }
 
 variable "server_alerts" {
-  description = "Prometheus server alerts entries in YAML"
+  description = "Prometheus server alerts entries in YAML. Ref: https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/"
 
   default = <<EOF
-## Alerts configuration
-## Ref: https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/
 alerts: {}
 # groups:
 #   - name: Instances

--- a/modules/prometheus/variables.tf
+++ b/modules/prometheus/variables.tf
@@ -1309,18 +1309,17 @@ variable "server_alerts" {
   description = "Prometheus server alerts entries in YAML. Ref: https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/"
 
   default = <<EOF
-alerts: {}
-# groups:
-#   - name: Instances
-#     rules:
-#       - alert: InstanceDown
-#         expr: up == 0
-#         for: 5m
-#         labels:
-#           severity: page
-#         annotations:
-#           description: '{{ $labels.instance }} of job {{ $labels.job }} has been down for more than 5 minutes.'
-#           summary: 'Instance {{ $labels.instance }} down'
+[]
+# - name: Instances
+#   rules:
+#     - alert: InstanceDown
+#       expr: up == 0
+#       for: 5m
+#       labels:
+#         severity: page
+#       annotations:
+#         description: '{{ $labels.instance }} of job {{ $labels.job }} has been down for more than 5 minutes.'
+#         summary: 'Instance {{ $labels.instance }} down'
 EOF
 
 }
@@ -1329,7 +1328,11 @@ variable "server_rules" {
   description = "Prometheus server rules entries in YAML"
 
   default = <<EOF
-rules: {}
+[]
+# - name: k8s_health
+#   rules:
+#     - record: k8s_container_oom
+#       expr: increase(kube_pod_container_status_last_terminated_reason{reason="OOMKilled"}[2m]) and on(pod) increase(kube_pod_container_status_restarts_total[2m])
 EOF
 
 }

--- a/modules/prometheus/variables.tf
+++ b/modules/prometheus/variables.tf
@@ -1719,12 +1719,12 @@ variable "vm_alert_helm_release_max_history" {
 
 variable "vm_alert_release_name" {
   description = "Helm release name for VictoriaMetrics Alert"
-  default     = "victoria-metrics-cluster"
+  default     = "victoria-metrics-alert"
 }
 
 variable "vm_alert_chart" {
   description = "Chart for VictoriaMetrics Alert"
-  default     = "victoria-metrics-cluster"
+  default     = "victoria-metrics-alert"
 }
 
 variable "vm_alert_chart_repository_url" {
@@ -1734,7 +1734,7 @@ variable "vm_alert_chart_repository_url" {
 
 variable "vm_alert_chart_version" {
   description = "Chart version for VictoriaMetrics Alert"
-  default     = "0.4.4"
+  default     = "0.0.16"
 }
 
 variable "vm_alert_namespace" {

--- a/modules/prometheus/variables.tf
+++ b/modules/prometheus/variables.tf
@@ -1360,7 +1360,7 @@ variable "vm_helm_release_max_history" {
 }
 
 variable "vm_release_name" {
-  description = "Helm release name for Argo"
+  description = "Helm release name for VictoriaMetrics"
   default     = "victoria-metrics-cluster"
 }
 
@@ -1370,7 +1370,7 @@ variable "vm_chart" {
 }
 
 variable "vm_chart_repository_url" {
-  description = "Chart Repository URL for Argo"
+  description = "Chart Repository URL for VictoriaMetrics"
   default     = "https://victoriametrics.github.io/helm-charts/"
 }
 
@@ -1702,4 +1702,112 @@ variable "vm_storage_vm_select_port" {
 variable "vm_storage_termination_grace_period_seconds" {
   description = "VictoriaMetrics Select server pods' termination grace period in seconds"
   default     = 60
+}
+
+#################################
+# VictoriaMetrics Alert service
+#################################
+variable "vm_alert_enabled" {
+  description = "Deploy VictoriaMetrics Alert"
+  default     = true
+}
+
+variable "vm_alert_helm_release_max_history" {
+  description = "The maximum number of history releases to keep track for the VM helm release"
+  default     = 20
+}
+
+variable "vm_alert_release_name" {
+  description = "Helm release name for VictoriaMetrics Alert"
+  default     = "victoria-metrics-cluster"
+}
+
+variable "vm_alert_chart" {
+  description = "Chart for VictoriaMetrics Alert"
+  default     = "victoria-metrics-cluster"
+}
+
+variable "vm_alert_chart_repository_url" {
+  description = "Chart Repository URL for VictoriaMetrics Alert"
+  default     = "https://victoriametrics.github.io/helm-charts/"
+}
+
+variable "vm_alert_chart_version" {
+  description = "Chart version for VictoriaMetrics Alert"
+  default     = "0.4.4"
+}
+
+variable "vm_alert_namespace" {
+  description = "Namespace for VictoriaMetrics Alert"
+  default     = "core"
+}
+
+variable "vm_alert_image_repository" {
+  description = "Image repository for VictoriaMetrics Alert server"
+  default     = "victoriametrics/vmalert"
+}
+
+variable "vm_alert_image_tag" {
+  description = "Image tag for VictoriaMetrics Alert server"
+  default     = "v1.37.4"
+}
+
+variable "vm_alert_extra_args" {
+  description = "Additional VictoriaMetrics Alert container arguments"
+  default     = {}
+}
+
+variable "vm_alert_tolerations" {
+  description = "Tolerations for VictoriaMetrics Alert server"
+  default     = []
+}
+
+variable "vm_alert_node_selector" {
+  description = "Node selector for VictoriaMetrics Alert server pods"
+  default     = {}
+}
+
+variable "vm_alert_affinity" {
+  description = "Affinity for VictoriaMetrics Alert server pods"
+  default     = {}
+}
+
+variable "vm_alert_pod_annotations" {
+  description = "Annotations for VictoriaMetrics Alert server pods"
+  default     = {}
+}
+
+variable "vm_alert_replica_count" {
+  description = "Number of replicas for VictoriaMetrics Alert server"
+  default     = 1
+}
+
+variable "vm_alert_resources" {
+  description = "Resources for VictoriaMetrics Alert server"
+  default     = {}
+}
+
+variable "vm_alert_security_context" {
+  description = "Security context for VictoriaMetrics Alert server pods defined as a map which will be serialized to JSON."
+  default     = {}
+}
+
+variable "vm_alert_service_annotations" {
+  description = "Annotations for VictoriaMetrics Alert server service"
+  default     = {}
+}
+
+variable "vm_alert_service_labels" {
+  description = "Labels for VictoriaMetrics Alert server service"
+  default     = {}
+}
+
+variable "vm_alert_service_port" {
+  description = "Service port for VictoriaMetrics Alert server"
+  default     = 8880
+}
+
+variable "vm_alert_service_type" {
+  description = "Type of service for VictoriaMetrics Alert server"
+  default     = "ClusterIP"
 }

--- a/modules/prometheus/vm.tf
+++ b/modules/prometheus/vm.tf
@@ -1,8 +1,3 @@
-locals {
-  prometheus_remote_write_api_url = var.vm_enabled && var.vm_insert_enabled ? "http://${helm_release.vm[0].metadata[0].name}-vminsert.${helm_release.vm[0].metadata[0].namespace}.svc.cluster.local:${var.vm_insert_service_port}/insert/0/prometheus" : ""
-  prometheus_query_api_url        = var.vm_enabled && var.vm_select_enabled ? "http://${helm_release.vm[0].metadata[0].name}-vmselect.${helm_release.vm[0].metadata[0].namespace}.svc.cluster.local:${var.vm_select_service_port}/select/0/prometheus" : ""
-}
-
 resource "helm_release" "vm" {
   count = var.vm_enabled ? 1 : 0
 

--- a/modules/prometheus/vmagent.tf
+++ b/modules/prometheus/vmagent.tf
@@ -39,7 +39,7 @@ locals {
     tolerations      = jsonencode(var.vm_alert_tolerations)
     affinity         = jsonencode(var.vm_alert_affinity)
 
-    alerts = indent(4, var.server_alerts)
-    rules  = indent(4, var.server_rules)
+    alerts = indent(6, yamldecode(var.server_alerts)["alerts"]["groups"])
+    rules  = indent(6, yamldecode(var.server_rules)["rules"]["groups"])
   }
 }

--- a/modules/prometheus/vmagent.tf
+++ b/modules/prometheus/vmagent.tf
@@ -39,7 +39,7 @@ locals {
     tolerations      = jsonencode(var.vm_alert_tolerations)
     affinity         = jsonencode(var.vm_alert_affinity)
 
-    alerts = indent(6, yamldecode(var.server_alerts)["alerts"]["groups"])
-    rules  = indent(6, yamldecode(var.server_rules)["rules"]["groups"])
+    alerts = yamldecode(var.server_alerts)["alerts"]["groups"]
+    rules  = yamldecode(var.server_rules)["rules"]["groups"]
   }
 }

--- a/modules/prometheus/vmagent.tf
+++ b/modules/prometheus/vmagent.tf
@@ -39,7 +39,7 @@ locals {
     tolerations      = jsonencode(var.vm_alert_tolerations)
     affinity         = jsonencode(var.vm_alert_affinity)
 
-    alerts = yamldecode(var.server_alerts)["alerts"]["groups"]
-    rules  = yamldecode(var.server_rules)["rules"]["groups"]
+    alerts = indent(8, var.server_alerts)
+    rules  = indent(8, var.server_rules)
   }
 }

--- a/modules/prometheus/vmagent.tf
+++ b/modules/prometheus/vmagent.tf
@@ -39,6 +39,7 @@ locals {
     tolerations      = jsonencode(var.vm_alert_tolerations)
     affinity         = jsonencode(var.vm_alert_affinity)
 
-    alerts = indent(4, var.vmalert_alerts)
+    alerts = indent(4, var.server_alerts)
+    rules  = indent(4, var.server_rules)
   }
 }

--- a/modules/prometheus/vmagent.tf
+++ b/modules/prometheus/vmagent.tf
@@ -22,7 +22,7 @@ locals {
 
     datasource_url   = local.prometheus_query_api_url
     remote_write_url = local.prometheus_remote_write_api_url
-    remote_read_url  = local.prometheus_query_api_url
+    remote_read_url  = local.prometheus_remote_read_api_url
     alertmanager_url = local.prometheus_alertmanager_url
     extra_args       = jsonencode(var.vm_alert_extra_args)
 

--- a/modules/prometheus/vmagent.tf
+++ b/modules/prometheus/vmagent.tf
@@ -17,7 +17,7 @@ resource "helm_release" "vm_alert" {
 locals {
   alert_values = {
     enabled          = var.vm_alert_enabled
-    image_repository = var.vm_insert_image_repository
+    image_repository = var.vm_alert_image_repository
     image_tag        = var.vm_alert_image_tag
 
     datasource_url   = local.prometheus_query_api_url

--- a/modules/prometheus/vmagent.tf
+++ b/modules/prometheus/vmagent.tf
@@ -1,0 +1,44 @@
+resource "helm_release" "vm_alert" {
+  count = var.vm_alert_enabled ? 1 : 0
+
+  name       = var.vm_alert_release_name
+  chart      = var.vm_alert_chart
+  repository = var.vm_alert_chart_repository_url
+  version    = var.vm_alert_chart_version
+  namespace  = var.vm_alert_namespace
+
+  max_history = var.vm_alert_helm_release_max_history
+
+  values = [
+    templatefile("${path.module}/templates/victoriametrics-alert.yaml", local.alert_values),
+  ]
+}
+
+locals {
+  alert_values = {
+    enabled          = var.vm_alert_enabled
+    image_repository = var.vm_insert_image_repository
+    image_tag        = var.vm_alert_image_tag
+
+    datasource_url   = local.prometheus_query_api_url
+    remote_write_url = local.prometheus_remote_write_api_url
+    remote_read_url  = local.prometheus_query_api_url
+    alertmanager_url = local.prometheus_alertmanager_url
+    extra_args       = jsonencode(var.vm_alert_extra_args)
+
+    service_annotations = jsonencode(var.vm_alert_service_annotations)
+    service_labels      = jsonencode(var.vm_alert_service_labels)
+    service_port        = var.vm_alert_service_port
+    service_type        = var.vm_alert_service_type
+
+    replica_count    = var.vm_alert_replica_count
+    security_context = jsonencode(var.vm_alert_security_context)
+    resources        = jsonencode(var.vm_alert_resources)
+    pod_annotations  = jsonencode(var.vm_alert_pod_annotations)
+    node_selector    = jsonencode(var.vm_alert_node_selector)
+    tolerations      = jsonencode(var.vm_alert_tolerations)
+    affinity         = jsonencode(var.vm_alert_affinity)
+
+    alerts = indent(4, var.vmalert_alerts)
+  }
+}


### PR DESCRIPTION
Deploys vmalert service if enabled and sends alerts to the existing Prometheus Alertmanager.

This PR introduces a breaking change in the way alerts and recording rules are specified in order to support both the existing Prometheus chart configuration and the new VictoriaMetrics Alert chart configuration. Rules will now be specified as a yaml array.