### PR TITLE
Address deprecate use of alert and recording_rules config

### DIFF
--- a/modules/prometheus/templates/server.yaml
+++ b/modules/prometheus/templates/server.yaml
@@ -296,20 +296,16 @@ server:
   livenessProbeTimeout: ${liveness_probe_timeout}
 
 serverFiles:
-  alerts:
+  alerting_rules.yml:
     groups:
       ${alerts}
-  rules:
+  recording_rules.yml:
     groups:
       ${rules}
 
   prometheus.yml:
     ${remote_write_configs}
     ${remote_read_configs}
-
-    rule_files:
-      - /etc/config/rules
-      - /etc/config/alerts
 
     scrape_configs:
       ${self_scrape_config}


### PR DESCRIPTION
Address deprecate use of alert and recording_rules config

See:
- https://github.com/helm/charts/blob/7546bf54c780ea144c03ba962c924ed353dfb089/stable/prometheus/values.yaml#L1180
- https://github.com/helm/charts/blob/7546bf54c780ea144c03ba962c924ed353dfb089/stable/prometheus/values.yaml#L1186