### PR TITLE
Fix K8s service data source usage

### DIFF
--- a/modules/consul/dns.tf
+++ b/modules/consul/dns.tf
@@ -3,7 +3,7 @@
 
 data "kubernetes_service" "consul_dns" {
   metadata {
-    name      = "${helm_release.consul.name}-dns"
+    name      = "${helm_release.consul.metadata[0].name}-dns"
     namespace = var.chart_namespace
   }
 }


### PR DESCRIPTION
During initial apply of the consul module, one could get an error like this:
```
Error: services "consul-dns" not found

  on .terraform/modules/consul/modules/consul/dns.tf line 4, in data "kubernetes_service" "consul_dns":
   4: data "kubernetes_service" "consul_dns" {
```
This is due to the helm release containing the k8s service not yet being deployed. 

PR changes to use `helm_release.consul.metadata[0]` as the `metadata` is an attribute that is only known after apply.